### PR TITLE
Make valid yaml by removing duplicate skip line. [ci skip]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,8 +16,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
-  skip: true  # [osx]
+  skip: true  # [win or osx]
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
The duplicate `skip` lines was more of a problem than I originally [thought](https://github.com/conda-forge/staged-recipes/pull/4663#discussion_r168486559). One of my maintenance scripts reads the `meta.yaml` file, and the duplicate `skip` entry causes an error.